### PR TITLE
Add REST API example for device state

### DIFF
--- a/user/example/devices/stateful_counter/device.py
+++ b/user/example/devices/stateful_counter/device.py
@@ -1,0 +1,58 @@
+from dataclasses import dataclass
+from typing import Any
+
+from eos.devices.base_device import BaseDevice
+
+
+@dataclass
+class CounterState:
+    """Simple state for the counter."""
+
+    value: int = 0
+
+
+class StatefulCounter(BaseDevice):
+    """Example device that stores state in a dataclass."""
+
+    async def _initialize(self, init_parameters: dict[str, Any]) -> None:
+        # Initialize the dataclass state
+        self.state = CounterState(value=int(init_parameters.get("initial", 0)))
+
+    async def _cleanup(self) -> None:
+        # Nothing to clean up in this simple example
+        pass
+
+    async def _report(self) -> dict[str, Any]:
+        # Report the current state so it can be inspected via the REST API
+        return {"value": self.state.value}
+
+    # Public methods exposed to tasks
+    def increment(self, amount: int = 1) -> int:
+        """Increment the counter by ``amount`` and return the new value."""
+        self.state.value += amount
+        return self.state.value
+
+    def decrement(self, amount: int = 1) -> int:
+        """Decrement the counter by ``amount`` and return the new value."""
+        self.state.value -= amount
+        return self.state.value
+
+    def get_state(self) -> dict[str, Any]:
+        """Return the current state as a dictionary."""
+        return {"value": self.state.value}
+
+    def set_state(self, value: int) -> None:
+        """Set the counter to ``value``."""
+        self.state.value = int(value)
+
+    def apply_operations(self, ops: list[dict[str, int]]) -> int:
+        """Apply a sequence of operations and return the final value."""
+        for op in ops:
+            action = op.get("action")
+            if action == "increment":
+                self.increment(int(op.get("amount", 1)))
+            elif action == "decrement":
+                self.decrement(int(op.get("amount", 1)))
+            elif action == "set":
+                self.set_state(int(op.get("value", 0)))
+        return self.state.value

--- a/user/example/devices/stateful_counter/device.yml
+++ b/user/example/devices/stateful_counter/device.yml
@@ -1,0 +1,5 @@
+type: stateful_counter
+desc: Simple counter device with externally managed state
+
+init_parameters:
+  initial: 0

--- a/user/example/labs/counter_lab/lab.yml
+++ b/user/example/labs/counter_lab/lab.yml
@@ -1,0 +1,9 @@
+type: counter_lab
+desc: Example lab with a stateful counter
+
+devices:
+  counter:
+    type: stateful_counter
+    computer: eos_computer
+    init_parameters:
+      initial: 0

--- a/user/example/tasks/batch_update_counter/task.py
+++ b/user/example/tasks/batch_update_counter/task.py
@@ -1,0 +1,13 @@
+from eos.tasks.base_task import BaseTask
+
+
+class BatchUpdateCounter(BaseTask):
+    async def _execute(
+        self,
+        devices: BaseTask.DevicesType,
+        parameters: BaseTask.ParametersType,
+        containers: BaseTask.ContainersType,
+    ) -> BaseTask.OutputType:
+        counter = devices.get_all_by_type("stateful_counter")[0]
+        new_value = counter.apply_operations(parameters["operations"])
+        return {"value": new_value}, None, None

--- a/user/example/tasks/batch_update_counter/task.yml
+++ b/user/example/tasks/batch_update_counter/task.yml
@@ -1,0 +1,20 @@
+type: Batch Update Counter
+desc: Apply multiple operations to the counter in one call
+
+device_types:
+  - stateful_counter
+
+input_parameters:
+  operations:
+    type: list
+    element_type: dict
+    value: []
+    desc: |
+      List of operations. Each entry should have an "action" key (increment,
+      decrement, set) and an "amount" or "value".
+
+output_parameters:
+  value:
+    type: int
+    unit: none
+    desc: The updated counter value

--- a/user/example/tasks/decrement_counter/task.py
+++ b/user/example/tasks/decrement_counter/task.py
@@ -1,0 +1,13 @@
+from eos.tasks.base_task import BaseTask
+
+
+class DecrementCounter(BaseTask):
+    async def _execute(
+        self,
+        devices: BaseTask.DevicesType,
+        parameters: BaseTask.ParametersType,
+        containers: BaseTask.ContainersType,
+    ) -> BaseTask.OutputType:
+        counter = devices.get_all_by_type("stateful_counter")[0]
+        new_value = counter.decrement(parameters["amount"])
+        return {"value": new_value}, None, None

--- a/user/example/tasks/decrement_counter/task.yml
+++ b/user/example/tasks/decrement_counter/task.yml
@@ -1,0 +1,18 @@
+type: Decrement Counter
+desc: Decrement a stateful counter device
+
+device_types:
+  - stateful_counter
+
+input_parameters:
+  amount:
+    type: int
+    unit: none
+    value: 1
+    desc: Amount to decrement the counter
+
+output_parameters:
+  value:
+    type: int
+    unit: none
+    desc: The updated counter value

--- a/user/example/tasks/increment_counter/task.py
+++ b/user/example/tasks/increment_counter/task.py
@@ -1,0 +1,13 @@
+from eos.tasks.base_task import BaseTask
+
+
+class IncrementCounter(BaseTask):
+    async def _execute(
+        self,
+        devices: BaseTask.DevicesType,
+        parameters: BaseTask.ParametersType,
+        containers: BaseTask.ContainersType,
+    ) -> BaseTask.OutputType:
+        counter = devices.get_all_by_type("stateful_counter")[0]
+        new_value = counter.increment(parameters["amount"])
+        return {"value": new_value}, None, None

--- a/user/example/tasks/increment_counter/task.yml
+++ b/user/example/tasks/increment_counter/task.yml
@@ -1,0 +1,18 @@
+type: Increment Counter
+desc: Increment a stateful counter device
+
+device_types:
+  - stateful_counter
+
+input_parameters:
+  amount:
+    type: int
+    unit: none
+    value: 1
+    desc: Amount to increment the counter
+
+output_parameters:
+  value:
+    type: int
+    unit: none
+    desc: The updated counter value

--- a/user/example/tasks/set_counter/task.py
+++ b/user/example/tasks/set_counter/task.py
@@ -1,0 +1,13 @@
+from eos.tasks.base_task import BaseTask
+
+
+class SetCounter(BaseTask):
+    async def _execute(
+        self,
+        devices: BaseTask.DevicesType,
+        parameters: BaseTask.ParametersType,
+        containers: BaseTask.ContainersType,
+    ) -> BaseTask.OutputType:
+        counter = devices.get_all_by_type("stateful_counter")[0]
+        counter.set_state(parameters["value"])
+        return {"value": counter.get_state()["value"]}, None, None

--- a/user/example/tasks/set_counter/task.yml
+++ b/user/example/tasks/set_counter/task.yml
@@ -1,0 +1,18 @@
+type: Set Counter
+desc: Set the counter to a specific value
+
+device_types:
+  - stateful_counter
+
+input_parameters:
+  value:
+    type: int
+    unit: none
+    value: 0
+    desc: The new counter value
+
+output_parameters:
+  value:
+    type: int
+    unit: none
+    desc: The updated counter value


### PR DESCRIPTION
## Summary
- document fetching and updating device state via REST API
- add Increment Counter task for updating device state
- add example lab with a stateful counter
- extend counter example with decrement and batch operations
- show curl example for batch update

## Testing
- `ruff check .`
- `pytest --maxfail=1 -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6846fb1983dc8328a53a884fde0227db