### PR TITLE
Add listing experiments endpoint

### DIFF
--- a/docs/user-guide/rest_api.rst
+++ b/docs/user-guide/rest_api.rst
@@ -6,6 +6,7 @@ Example functions include:
 * Submit tasks, experiments, and campaigns, as well as cancel them
 * Load, unload, and reload experiments and laboratories
 * Get the status of tasks, experiments, and campaigns
+* List experiments with optional filters to retrieve experiment IDs
 * Download task output files
 
 .. warning::

--- a/eos/orchestration/services/experiment_service.py
+++ b/eos/orchestration/services/experiment_service.py
@@ -42,6 +42,10 @@ class ExperimentService:
         """Get an experiment by its unique identifier."""
         return await self._experiment_manager.get_experiment(db, experiment_id)
 
+    async def get_experiments(self, db: AsyncDbSession, **filters: Any) -> list[Experiment]:
+        """Get all experiments matching the provided filters."""
+        return await self._experiment_manager.get_experiments(db, **filters)
+
     async def submit_experiment(
         self,
         db: AsyncDbSession,

--- a/eos/web_api/controllers/experiment_controller.py
+++ b/eos/web_api/controllers/experiment_controller.py
@@ -46,6 +46,19 @@ class ExperimentController(Controller):
 
         return experiment
 
+    @get("/")
+    async def list_experiments(
+        self,
+        db: AsyncDbSession,
+        orchestrator: Orchestrator,
+        status: str | None = None,
+    ) -> list[Experiment]:
+        """List experiments filtered by optional status."""
+        filters: dict[str, Any] = {}
+        if status:
+            filters["status"] = status
+        return await orchestrator.experiments.get_experiments(db, **filters)
+
     @get("/types")
     async def get_experiment_types(self, orchestrator: Orchestrator) -> dict[str, bool]:
         """List experiment types."""


### PR DESCRIPTION
## Summary
- expose `get_experiments` in `ExperimentService`
- add `GET /experiments` API route with optional `status` filter
- document experiment listing endpoint

## Testing
- `python scripts/dev/format.py`
- `python scripts/dev/lint.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6846eded03d483288181d054a49d0b54